### PR TITLE
1st-shot: code-review, backwards-compatibilies, etc

### DIFF
--- a/cmdutils.js
+++ b/cmdutils.js
@@ -57,6 +57,16 @@ CmdUtils.CreateCommand = function CreateCommand(args) {
     CmdUtils.CommandList.push(args);
 };
 
+// create search command using url
+CmdUtils.makeSearchCommand = function makeSearchCommand(args) {
+    args.execute = function(a) {
+        var url = args.url.replace(/\{QUERY\}/g, encodeURIComponent(a.text));
+        CmdUtils.addTab(url);
+    }
+    CmdUtils.CreateCommand(args);
+};
+
+
 // closes current tab
 CmdUtils.closeTab = function closeTab() {
 	chrome.tabs.query({active:true,currentWindow:true},function(tabs){

--- a/cmdutils.js
+++ b/cmdutils.js
@@ -25,8 +25,13 @@ CmdUtils.deblog = function () {
 
 // creates command and adds it to command array, name or names must be provided and preview execute functions
 CmdUtils.CreateCommand = function CreateCommand(args) {
-    args.name = args.name || args.names[0];
-    args.names = args.names || [args.name];
+    if (Array.isArray(args.name)) {
+        args.names = args.name;
+        args.name = args.name[0];
+    } else {
+        args.name = args.name || args.names[0];
+        args.names = args.names || [args.name];
+    }
     if (CmdUtils.getcmd(args.name)) {
         // remove previously defined command with this name
         CmdUtils.CommandList = CmdUtils.CommandList.filter( cmd => cmd.name !== args.name );
@@ -63,9 +68,116 @@ CmdUtils.makeSearchCommand = function makeSearchCommand(args) {
         var url = args.url.replace(/\{QUERY\}/g, encodeURIComponent(a.text));
         CmdUtils.addTab(url);
     }
+    if ((typeof args.preview != 'function') && args.preview != 'none') {
+        args.preview = CmdUtils._searchCommandPreview;
+        if (args.prevAttrs == null) {
+            args.prevAttrs = {zoom: 0.85};
+        }
+    }
     CmdUtils.CreateCommand(args);
 };
 
+// helper to avoid stealing focus in preview
+CmdUtils._restoreFocusToInput = function(event) {
+    var wnd = event.currentTarget || event.view;
+    var doc;
+    if (!wnd.closed && !((doc = wnd.document).hidden || doc.webkitHidden || doc.mozHidden || doc.msHidden)) {
+        wnd.setTimeout( function() {
+            wnd.document.getElementById('ubiq_input').focus();
+        }, 0);
+        var self = wnd._ubiq_recent_cmd;
+        // may be scrolled by set of focus - so restore it now:
+        if (self.prevAttrs.scroll) {
+            var scrollOffs = self.prevAttrs.scroll;
+            wnd.setTimeout( function() {
+                var pblock = wnd.document.getElementById('ubiq-preview-div');
+                pblock.scrollLeft = scrollOffs[0];
+                pblock.scrollTop = scrollOffs[1];
+            }, 0);
+        }
+        wnd.setTimeout(function() {
+            wnd.removeEventListener("blur", CmdUtils._restoreFocusToInput, { capture: true });
+        }, 150);
+    } else {
+        wnd.removeEventListener("blur", CmdUtils._restoreFocusToInput, { capture: true });
+    }
+};
+
+CmdUtils._afterLoadPreview = function(ifrm) {
+    var doc = ifrm.ownerDocument;
+    var wnd = doc.defaultView || doc.parentWindow;
+    wnd.focus();
+    // jump to anchor (try multiple one by one):
+    if (this.prevAttrs.anchor != null) {
+      var url = ifrm.src;
+      for (var ha of this.prevAttrs.anchor) {
+        ifrm.src = url.replace(/(?:\#[^#]+)?$/, '#' + ha);
+      }
+    }
+    // restore focus:
+    wnd.focus();
+    wnd.removeEventListener("blur", CmdUtils._restoreFocusToInput, { capture: true });
+}
+
+// default common preview for search commands
+CmdUtils._searchCommandPreview = function _searchCommandPreview( pblock, {text: text} ) {
+    var q = text;
+    var code = (this.description || "Search") + " for <b> '" + (q || "...") + "'</b>";
+    pblock.innerHTML = code;
+    if (q == null || q == '') {
+      return;
+    }
+    if (!this.prevAttrs) this.prevAttrs = {};
+    var url = (this.prevAttrs.url || this.url).replace(/\{QUERY\}/g, q);
+    // hash-anchor:
+    var hashanch = null;
+    if (this.prevAttrs.anchor != null) {
+      var hashanch = this.prevAttrs.anchor;
+      if (!Array.isArray(hashanch)) {
+        hashanch = this.prevAttrs.anchor = [hashanch];
+      }
+      url += '#'+hashanch[0];
+    }
+    var zoom = this.prevAttrs.zoom || 0.85;
+    //pblock.style.overflow = 'hidden'; 
+    var doc = pblock.ownerDocument;
+    var wnd = doc.defaultView || doc.parentWindow;
+    if (wnd._ubi_prevTO != null) {
+      wnd.clearTimeout(wnd._ubi_prevTO);
+      wnd._ubi_prevTO = null;
+    }
+    var to = 300;
+    var self = this;
+    // show it:
+    wnd._ubi_prevTO = wnd.setTimeout(function () {
+      // avoid stealing focus (and re-scroll):
+      wnd.removeEventListener("blur", CmdUtils._restoreFocusToInput, { capture: true });
+      wnd.addEventListener("blur", CmdUtils._restoreFocusToInput, { capture: true });
+      wnd._ubiq_recent_cmd = self;
+      // parent block in order to handle scroll ("cross origin" issue) and to provide zoom
+      pblock.innerHTML = 
+    '<div id="ubiq-preview-div" style="--zoom:'+ zoom +'">'+ code +'</div>';
+      pblock = pblock.lastChild;
+      // scrollTo in frame cross origin not allowed in some browsers - scroll later inside parent div:
+      var scrollOffs = [0, 0];
+      if (self.prevAttrs.scroll) {
+        scrollOffs = self.prevAttrs.scroll;
+      }
+      pblock.innerHTML =
+     '<iframe id="ubiq-preview-frm"' +
+       ' sandbox="allow-same-origin allow-scripts allow-popups allow-forms"' +
+       ' style="--scrollX:'+ scrollOffs[0] +'px; --scrollY:'+ scrollOffs[1] +'px; "'+
+       ' src="' + url + '"/>';
+      var ifrm = pblock.lastChild;
+      ifrm.onload = function() { (CmdUtils._afterLoadPreview.bind(self))(pblock.lastChild); };
+      if (scrollOffs[0] || scrollOffs[1]) {
+        wnd.setTimeout(function() {
+          pblock.scrollLeft = scrollOffs[0];
+          pblock.scrollTop = scrollOffs[1];
+        }, 10);
+      }
+    }, to);
+}
 
 // closes current tab
 CmdUtils.closeTab = function closeTab() {

--- a/cmdutils.js
+++ b/cmdutils.js
@@ -338,6 +338,8 @@ CmdUtils.updateSelection = function (tab_id) {
 
 // called when tab is switched or changed, updates selectedText and activeTab
 CmdUtils.updateActiveTab = function () {
+    CmdUtils.active_tab = null;
+    CmdUtils.selectedText = '';
     if (chrome.tabs && chrome.tabs.getSelected)
     chrome.tabs.getSelected(null, function(tab) {
         if (tab.url.match('^https?://')){

--- a/options.html
+++ b/options.html
@@ -14,7 +14,8 @@
 			<div id="buttons">
 				<a href=# id="download"  >download scripts</a> - insert example commands: 
 				<a href=# id="insertnotifystub">notify</a> -
-				<a href=# id="insertsearchstub">search</a>
+				<a href=# id="insertsearchstub">search</a> -
+				<a href=# id="insertenhsearchstub">enhanced search</a>
 			</div>
 		</div>
 	</div>

--- a/options.js
+++ b/options.js
@@ -1,8 +1,10 @@
 // jshint esversion: 6
 
-// inserts simple notify command 
-function insertNotifyStub() {
-    var stub = 
+// inserts stub (example command)
+function insertExampleStub() {
+
+    var stubs = {
+  'insertnotifystub': // simple notify command 
 `/* This is a template command. */
 CmdUtils.CreateCommand({
     name: "1example",
@@ -17,14 +19,8 @@ CmdUtils.CreateCommand({
     },
 });
 
-`;
-    editor.replaceRange(stub, editor.getCursor());
-    saveScripts();
-}
-
-// inserts simple search / preview command
-function insertSearchStub() {
-    var stub = 
+`
+, 'insertsearchstub': // simple search / preview command (e. g. using ajax)
 `/* This is a template command. */
 CmdUtils.CreateCommand({
     name: "2example",
@@ -41,11 +37,27 @@ CmdUtils.CreateCommand({
     },
 });
 
-`;
+`
+, 'insertenhsearchstub': // enhanced search / preview command
+`/* This is a template command. */
+CmdUtils.makeSearchCommand({
+  name: ["3example"],
+  description: "Searches quant.com",
+  author: {name: "Your Name", email: "your-mail@example.com"},
+  icon: "https://www.qwant.com/favicon-152.png?1503916917494",
+  url: "https://www.qwant.com/?q={QUERY}&t=all",
+  prevAttrs: {zoom: 0.75, scroll: [100/*x*/, 0/*y*/], anchor: ["c_13", "c_22"]},
+});
+
+`
+    };
+
+    var stub = stubs[this.id];
     editor.replaceRange(stub, editor.getCursor());
 
     //editor.setValue( stub + editor.getValue() );
     saveScripts();
+    return false;
 }
 
 // evaluates and saves scripts from editor
@@ -88,8 +100,9 @@ editor = CodeMirror.fromTextArea( document.getElementById("code"), {
 editor.on("blur", saveScripts);
 editor.on("change", saveScripts);
 
-$("#insertnotifystub").click( insertNotifyStub );	
-$("#insertsearchstub").click( insertSearchStub );	
+$("#insertnotifystub").click( insertExampleStub );
+$("#insertsearchstub").click( insertExampleStub );
+$("#insertenhsearchstub").click( insertExampleStub );
 
 // load scrtips
 if (typeof chrome !== 'undefined' && chrome.storage) {

--- a/popup.css
+++ b/popup.css
@@ -25,19 +25,19 @@ body {
 
 #ubiq-input-panel {
     border: 0;
-    display: block;
-    float: left;
     margin: 0;
     width: 100%;
-    height: 55px
+    height: 24pt;
 }
 
 #ubiq_input {
+    border: 1px solid #3D3D3D;
     width: 100%;
-    border: 0px;
-    height: 55px;
+    height: 100%;
     margin: 0px;
-    background: lightgray;
+    padding-left: 4pt;
+    padding-right: 4pt;
+    background: #d3d3d3;
     color: #333;
     font-size: 18pt;
     -webkit-appearance: none;
@@ -56,56 +56,86 @@ body {
     display: block;
 }
 
+#ubiq-bottom-panel {
+    height: 100%;
+}
+#ubiq-command-panel {
+    width: 540px; height: 100%;
+    vertical-align: top;
+}
+
 #ubiq-command-tip {
-    position: absolute;
-    left: 300px;
-    top: 57px;
     color: #ddd;
     font-style: italic;
+    width: 540px; height: 0px;
 }
 
 #ubiq-command-preview {
-    position: absolute;
-    left: 300px;
-    top: 57px;
     color: #ddd;
+    width: 540px; height: 525px;
+    position: relative;
 }
 
 #ubiq-command-preview a {
     color:white;
     text-decoration: bold;
-    font-size: 11.5pt
+    font-size: 11.5pt;
+}
+#ubiq-command-preview #ubiq-preview-div {
+    --zoom: 1.0;
+    transform: scale(var(--zoom)); transform-origin: 0px 0px;
+    -moz-transform: scale(var(--zoom)); -moz-transform-origin: 0 0;
+    -webkit-transform: scale(var(--zoom)); -webkit-transform-origin: 0 0;
+    width: calc(100% / var(--zoom) / 1.02) !important;
+    height: calc(100% / var(--zoom)) !important;
+    overflow: auto; position: relative; border:0px;
+}
+#ubiq-preview-div #ubiq-preview-frm {
+    --scrollX: 0px;
+    --scrollY: 0px;
+    width: calc(100% - 4px + var(--scrollX)) !important; 
+    height: calc(100% - 4px + var(--scrollY)) !important;
+    background-color: transparent;
+    border: 0px;
 }
 
 #ubiq-result-panel {
+    vertical-align: top;
     width: 100%;
     margin: 0;
-    float: left;
     clear: both;
     text-align: left;
     padding-top: 2px;
     color: white;
-    height: 502px;
+    height: 525px;
 }
-
+#ubiq-result-panel.result {
+  padding-left: 4pt;
+  padding-right: 4pt;
+}
 #ubiq-result-panel ul {
 	padding:0; 
-	margin:0
+	margin:0;
+    width: 248px; 
+    height: 100%;
 }
 
 #ubiq-result-panel li {
 	color: black; 
 	list-style: none; 
 	margin: 0; 
-	padding-top: 8px; 
+    padding-top: 2pt;
+	vertical-align: middle;
 	padding-left: 12px;
-	font-size: 14px; 
-	height: 26px;
-	width: 288px; 
+	font-size: 12pt;
+	height: 22pt;
 	background-color: #a9a9a9; 
 	background-repeat: repeat;
 }
+#ubiq-result-panel li img {
+    height: 20pt;
+}
 
 #ubiq-result-panel li.selected {
-	background-color: gray; 
+	background-color: #d3d3d3; 
 }

--- a/popup.css
+++ b/popup.css
@@ -129,8 +129,11 @@ body {
 	padding-left: 12px;
 	font-size: 12pt;
 	height: 22pt;
-	background-color: #a9a9a9; 
+    width: 225px;
+	background-color: #a9a9a9;
 	background-repeat: repeat;
+    border: 1px outset #ddd;
+    cursor: default;
 }
 #ubiq-result-panel li img {
     height: 20pt;
@@ -138,4 +141,24 @@ body {
 
 #ubiq-result-panel li.selected {
 	background-color: #d3d3d3; 
+    background: linear-gradient(#efefef, #b0b0b0);
+    position:relative;
+    width: 225px;
+}
+#ubiq-result-panel .more-commands {
+    width: 225px;
+    line-height: 10px;
+    text-align: center;
+}
+#ubiq-result-panel li.selected::after {
+    position:absolute;
+    top:0%;
+    left:100%;
+    content:"";
+    margin-left:0px;
+    width: 0; 
+    height: 0; 
+    border-top: 11pt solid transparent;
+    border-bottom: 12pt solid transparent;
+    border-left: 7pt solid #d3d3d3;
 }

--- a/popup.html
+++ b/popup.html
@@ -8,17 +8,22 @@
 
 <body>
     <div id="ubiq_window">
-        <div id="ubiq-input-panel">
-            <input id="ubiq_input" autofocus autocomplete="off" spellcheck="false" type="text" size="60" maxlength="500">
-        </div>
-        <br>
-        <div id="ubiq-result-panel">
+    <table border="0" cellpadding="0" cellspacing="0">
+        <tr><td colspan="2" id="ubiq-input-panel">
+            <input id="ubiq_input" autofocus autocomplete="off" spellcheck="false" type="text" size="60" maxlength="500"/>
+        </td></tr>
+        <tr id="ubiq-bottom-panel">
+            <td id="ubiq-result-panel">
             <p style="font-size:17px; padding:8px; font-weight:normal">
                 Type the name of a command and press enter to execute it.
             </p>
-        </div>
-        <div id="ubiq-command-tip"></div>
-        <div id="ubiq-command-preview"></div>
+            </td>
+            <td id="ubiq-command-panel">
+                <div id="ubiq-command-tip"></div>
+                <div id="ubiq-command-preview"></div>
+            </td>
+        </tr>
+    </table>
     </div>
     UbiChr 0.1
 </body>

--- a/popup.js
+++ b/popup.js
@@ -95,7 +95,9 @@ function ubiq_show_preview(cmd, args) {
             } catch (e) {
                 CmdUtils.notify(e.toString(), "preview function error")
                 console.error(e.stack);
-                CmdUtils.backgroundWindow.error(e.stack);
+                if (CmdUtils.backgroundWindow && CmdUtils.backgroundWindow.error) {
+                    CmdUtils.backgroundWindow.error(e.stack);
+                }
             }
         }
 

--- a/popup.js
+++ b/popup.js
@@ -64,10 +64,10 @@ function ubiq_clear() {
 
 // shows preview for command, cmd is command index
 function ubiq_show_preview(cmd, args) {
-    if (!cmd) return;
+    if (cmd == null) return;
     var cmd_struct = CmdUtils.CommandList[cmd];
     if (!cmd_struct || !cmd_struct.preview) return;
-    preview_func = cmd_struct.preview;
+    var preview_func = cmd_struct.preview;
     switch(typeof preview_func)
     {
     case 'undefined':

--- a/popup.js
+++ b/popup.js
@@ -53,7 +53,6 @@ function ubiq_set_result(v, prepend) {
     if (!el) return;
     el.innerHTML = v + (prepend ? "<hr/>" + el.innerHTML : "");
     if (v!="") ubiq_set_preview("");
-    ubiq_preview_set_visible(false);
 }
 
 // clears tip, result and preview panels
@@ -65,7 +64,6 @@ function ubiq_clear() {
 
 // shows preview for command, cmd is command index
 function ubiq_show_preview(cmd, args) {
-    ubiq_preview_set_visible(true);
     if (!cmd) return;
     var cmd_struct = CmdUtils.CommandList[cmd];
     if (!cmd_struct || !cmd_struct.preview) return;
@@ -371,11 +369,14 @@ function ubiq_show_matching_commands(text) {
 
         for (var c in matches) {
             var is_selected = (c == ubiq_selected_command);
-            var li = document.createElement('li');
             c = matches[c];
+            var li;
             if (c == '...') {
+                li = document.createElement('DIV');
+                li.setAttribute('class', 'more-commands');
                 li.innerHTML = c;
             } else {
+                li = document.createElement('LI');
                 var foundname = c[1];
                 c = c[0];
                 var cmd = ubiq_command_name(c);
@@ -384,14 +385,16 @@ function ubiq_show_matching_commands(text) {
                 //if (foundname != cmd) { foundname = cmd + " (" + foundname + ")" };
                 li.innerHTML = icon + ubiq_html_encode(foundname);
             }
-            li.setAttribute('class', is_selected ? 'selected' : '');
+            if (is_selected)
+                li.setAttribute('class', 'selected');
             suggestions_list.appendChild(li);
         }
 
         suggestions_div.appendChild(suggestions_list);
         ubiq_result_el().innerHTML = suggestions_div.innerHTML; // shouldn't clear the preview
-
+        ubiq_preview_set_visible(true);
     } else {
+        ubiq_preview_set_visible(false);
         ubiq_selected_command = -1;
         ubiq_clear();
         ubiq_set_result( ubiq_help() );


### PR DESCRIPTION
* adjusted style (more similar to dark theme of ubiquity)
* CmdUtils extended with makeSearchCommand (backwards compatibility to previous Ubiquity version);
* code review and enhancements:
  - introduced fuzzy search for command, commands sorted by rank (weight) and alphanumeric inside weights;
  - extended with common default preview functionality (CmdUtils._searchCommandPreview, etc);
  example for custom search-preview see insertenhsearchstub in options.js (or click on "enhanced search" in command-editor);
  - usage of `this` allowed now by execution of preview (backwards compatibility);
  - many fixes on style/dom of the ubiquity window, switched to table-layout (more responsive resp. RWD-capable now);
* reset tab/selection by update active tab (chrome, etc.)
* fix sporadic error if CmdUtils.backgroundWindow.error not available

### Examples for makeSearchCommand (with extended direct-preview):
```js
CmdUtils.makeSearchCommand({
  name: ["dict-cc", "dict-en"],
  author: {name: "Serg G. Brester (sebres)"},
  url: "http://www.dict.cc/?s={QUERY}",
  prevAttrs: {zoom: 0.8, scroll: [165 /*x*/, 200 /*y*/]},
  icon: "http://www.dict.cc/img/favicons/favicon4.png",
  description: "Searches dict.cc"
});

CmdUtils.makeSearchCommand({
  name: ["qwant"],
  author: {name: "Serg G. Brester (sebres)"},
  url: "https://www.qwant.com/?q={QUERY}&t=all",
  prevAttrs: {zoom: 0.75, scroll: [100, 0/*180*/], anchor: ["c_13", "c_22"] /*try to jump hash-anchors*/},
  icon: "https://www.qwant.com/favicon-152.png?1503916917494",
  description: "Searches quant.com"
});

CmdUtils.makeSearchCommand({
  name: "whois",
  author: {name: "Serg G. Brester (sebres)"},
  url: "http://whois.domaintools.com/{QUERY}",
  preview: 'none',
  icon: "http://whois.domaintools.com/favicon.ico",
  description: "Whois domaintools"
});

```