### PR TITLE
Initial simplification for command selection

### DIFF
--- a/cmdutils.js
+++ b/cmdutils.js
@@ -120,7 +120,7 @@ CmdUtils._afterLoadPreview = function(ifrm) {
 }
 
 // default common preview for search commands
-CmdUtils._searchCommandPreview = function _searchCommandPreview( pblock, {text: text} ) {
+CmdUtils._searchCommandPreview = function _searchCommandPreview( pblock, {input: text} ) {
     var q = text;
     var code = (this.description || "Search") + " for <b> '" + (q || "...") + "'</b>";
     pblock.innerHTML = code;
@@ -242,7 +242,7 @@ CmdUtils.SimpleUrlBasedCommand = function SimpleUrlBasedCommand(url) {
     if (!url) return;
     var search_func = function(directObj) {
         if (!directObj) return;
-        var text = directObj.text;
+        var text = directObj.input;
         text = encodeURIComponent(text);
         var finalurl = url;
         finalurl = finalurl.replace('{text}', text);

--- a/commands.js
+++ b/commands.js
@@ -93,7 +93,7 @@ CmdUtils.CreateCommand({
     homepage: "",
     license: "",
     preview: "Perform a clustered search through yippy.com",
-    execute: async function execute({text:text}) {
+    execute: async function execute({input:text}) {
             var xtoken = CmdUtils.get("http://yippy.com/");
             xtoken = jQuery("#xtoken", xtoken).val();
             CmdUtils.postNewTab("http://yippy.com/search/?v%3Aproject=clusty-new&query=kakao&xtoken="+xtoken);//, {"v:project":"clusty-new", xtoken:xtoken});
@@ -140,7 +140,7 @@ CmdUtils.CreateCommand({
     license: "",
     preview: async function (pblock, directObj) {
         pblock.innerHTML = "Convert currency values using xe.com converter service.";
-        var currency_spec = directObj.text;
+        var currency_spec = directObj.input;
         var matches = currency_spec.match(/^([\d\.]+)\s+(\w+)\s+to\s+(\w+)$/);
         if (!matches || matches.length<3) return;
         var amount = matches[1];
@@ -151,7 +151,7 @@ CmdUtils.CreateCommand({
         jQuery(pblock).load( xe_url+" .uccAmountWrap");
     },
     execute: function (directObj) {
-        var currency_spec = directObj.text;
+        var currency_spec = directObj.input;
         var matches = currency_spec.match(/^([\d\.]+)\s+(\w+)\s+to\s+(\w+)$/);
         var amount = matches[1];
         var curr_from = matches[2].toUpperCase();
@@ -172,10 +172,10 @@ CmdUtils.CreateCommand({
     help: "Try issuing &quot;dictionary ubiquity&quot;",
     license: "MPL",
     icon: "http://dictionary.reference.com/favicon.ico",
-    execute: function ({text: text}) {
+    execute: function ({input: text}) {
         CmdUtils.addTab("http://dictionary.reference.com/search?q=" + escape(text));
     },
-    preview: async function define_preview(pblock, {text: text}) {
+    preview: async function define_preview(pblock, {input: text}) {
         pblock.innerHTML = "Gives the meaning of a word.";
         var doc = await CmdUtils.get("http://dictionary.reference.com/search?q="+encodeURIComponent(text)+"&s=tt&ref_=fn_al_tt_mr" );
         doc = jQuery("div.source-box", doc)
@@ -241,14 +241,6 @@ CmdUtils.CreateCommand({
 });
 
 CmdUtils.CreateCommand({
-    names: ["help", "command-list"],
-    description: "Provides basic help on using Ubiquity",
-    icon: "res/icon-128.png",
-    preview: "lists all avaiable commands",
-    execute: CmdUtils.SimpleUrlBasedCommand("help.html")
-});
-
-CmdUtils.CreateCommand({
     names: ["debug-popup"],
     description: "Open popup in window",
     icon: "res/icon-128.png",
@@ -284,7 +276,7 @@ CmdUtils.CreateCommand({
     icon: "http://www.imdb.com/favicon.ico",
     homepage: "",
     license: "",
-    preview: async function define_preview(pblock, {text: text}) {
+    preview: async function define_preview(pblock, {input: text}) {
         pblock.innerHTML = "Searches for movies on IMDb";
         if (text.trim()!="") 
         // jQuery(pblock).load("http://www.imdb.com/find?q="+encodeURIComponent(text)+"&s=tt&ref_=fn_al_tt_mr table.findList")
@@ -315,7 +307,7 @@ CmdUtils.CreateCommand({
     preview: function (pblock, directObject) {
         //ubiq_show_preview(urlString);
         //searchText = jQuery.trim(directObject.text);
-        var host = directObject.text;
+        var host = directObject.input;
         if (host.length < 1) {
             pblock.innerHTML = "Checks if URL is down";
             return;
@@ -325,7 +317,7 @@ CmdUtils.CreateCommand({
     },
     execute: async function (directObject) {
         var url = "http://downforeveryoneorjustme.com/{QUERY}";
-        var query = directObject.text;
+        var query = directObject.input;
         CmdUtils.setPreview("checking "+query);
         // Get the hostname from url
         if (!query) {
@@ -475,7 +467,7 @@ CmdUtils.CreateCommand({
     homepage: "",
     license: "",
     preview: "Open a new tab (or window) with the specified URL",
-    execute: function ({text:text}) {
+    execute: function ({input:text}) {
         if (!text.match('^https?://')) text = "http://"+text;
         CmdUtils.addTab(text);
     }
@@ -497,7 +489,7 @@ CmdUtils.CreateCommand({
     icon: "http://www.google.com/favicon.ico",
     homepage: "",
     license: "",
-    preview: async function define_preview(pblock, {text: text}) {
+    preview: async function define_preview(pblock, {input: text}) {
         text = text.trim();
         pblock.innerHTML = "Search on Google for "+text;
         if (text!="") {
@@ -528,7 +520,7 @@ CmdUtils.CreateCommand({
         email: "cosimo@cpan.org"
     },
     license: "GPL",
-    preview: async function (pblock, {text:text}) {
+    preview: async function (pblock, {input:text}) {
         var words = text.split(' ');
         var host = words[1];
         pblock.innerHTML = "Shortens an URL (or the current tab) with bit.ly";
@@ -687,7 +679,7 @@ CmdUtils.CreateCommand({
     <a href="http://www.microsofttranslator.com">Bing Translator</a> toolbar.\
   ',
     author: "based on original ubiquity translate command",
-    execute: async function translate_execute({text: text, _selection: _selection}) {
+    execute: async function translate_execute({input: text, _selection: _selection}) {
         var words = text.split(/\s+/);
         var dest = 'en';
 
@@ -713,7 +705,7 @@ CmdUtils.CreateCommand({
             CmdUtils.setPreview("text is too short or too long. try translating <a target=_blank href=https://www.bing.com/translator/>manually</a>");
         }
     },
-    preview: async function translate_preview(pblock, {text: text}) {
+    preview: async function translate_preview(pblock, {input: text}) {
         var words = text.split(/\s+/);
         var dest = 'en';
 
@@ -763,7 +755,7 @@ CmdUtils.CreateCommand({
     },
     execute: function (directObj) {
         CmdUtils.closePopup();
-        var url = directObj.text;
+        var url = directObj.input;
         if (!url) url = CmdUtils.getLocation();
         var wayback_machine = "http://web.archive.org/web/*/" + url;
         // Take me back!
@@ -791,12 +783,12 @@ CmdUtils.CreateCommand({
     license: "",
     preview: function wikipedia_preview(previewBlock, args) {
         var args_format_html = "English";
-        var searchText = args.text.trim();
+        var searchText = args.input.trim();
         if (!searchText) {
             previewBlock.innerHTML = "Searches Wikipedia in " + args_format_html + ".";
             return;
         }
-        previewBlock.innerHTML = "Searching Wikipedia for <b>" + args.text + "</b> ...";
+        previewBlock.innerHTML = "Searching Wikipedia for <b>" + args.input + "</b> ...";
 
         function onerror() {
             previewBlock.innerHTML =
@@ -866,7 +858,7 @@ CmdUtils.CreateCommand({
     description: desc = "evals math expressions",
     icon: "https://png.icons8.com/metro/50/000000/calculator.png",
     require: "https://cdnjs.cloudflare.com/ajax/libs/mathjs/3.20.1/math.min.js",
-    preview: pr = function preview(previewBlock, {text:text}) {
+    preview: pr = function preview(previewBlock, {input:text}) {
     	if (text.trim()!='') {
     		var m = new math.parser();
     		text = text.replace(",",".");
@@ -877,7 +869,7 @@ CmdUtils.CreateCommand({
 		else
 	        previewBlock.innerHTML = desc;
     },
-    execute: function ({text:text}) { 
+    execute: function ({input:text}) { 
     	if (text.trim()!='') {
     		var m = new math.parser();
     		text = text.replace(",",".");
@@ -906,7 +898,7 @@ CmdUtils.CreateCommand({
     execute: CmdUtils.SimpleUrlBasedCommand(
         "http://answers.com/search?q={text}"
     ),
-    preview: async function define_preview(pblock, {text: text}) {
+    preview: async function define_preview(pblock, {input: text}) {
         if (text.trim()=="") {
             pblock.innerHTML = "Gives the definition from answers.com";
             return;
@@ -931,10 +923,10 @@ CmdUtils.CreateCommand({
         name: "von rostock",
     },
     license: "GPL",
-    execute: function execute({text:text}) {
+    execute: function execute({input:text}) {
         CmdUtils.setSelection(atob(text));
     },
-    preview: function preview(pblock, {text:text}) {
+    preview: function preview(pblock, {input:text}) {
         pblock.innerHTML = atob(text);
     },
 });
@@ -946,10 +938,10 @@ CmdUtils.CreateCommand({
         name: "von rostock",
     },
     license: "GPL",
-    execute: function execute({text:text}) {
+    execute: function execute({input:text}) {
         CmdUtils.setSelection(btoa(text));
     },
-    preview: function preview(pblock, {text:text}) {
+    preview: function preview(pblock, {input:text}) {
         pblock.innerHTML = btoa(text);
     },
 });
@@ -1014,5 +1006,13 @@ chrome.storage.local.get('customscripts', function(result) {
 	} catch (e) {
 		console.error("custom scripts eval failed", e);
 	}
+});
+
+CmdUtils.CreateCommand({
+    names: ["help", "command-list"],
+    description: "Provides basic help on using Ubiquity",
+    icon: "res/icon-128.png",
+    preview: CmdUtils.CommandList.map( cmd => cmd.names.join(", ") ).concat(["help", "command-list"]).sort().join(", "),
+    execute: CmdUtils.SimpleUrlBasedCommand("help.html")
 });
 

--- a/commands.js
+++ b/commands.js
@@ -460,12 +460,8 @@ CmdUtils.CreateCommand({
         }
     },
     execute: function(directObj) {
-        message = ""
-        for (var key in directObj)
-            message += key + " == " + String(directObj[key]) + "\n"
-        console.log(message)
-        //if (text.substr(-2)=="-l") text = text.slice(0,-2);
-        //CmdUtils.addTab("http://maps.google.com/maps?q="+encodeURIComponent(text));
+        if (text.substr(-2)=="-l") text = text.slice(0,-2);
+        CmdUtils.addTab("http://maps.google.com/maps?q="+encodeURIComponent(text));
     }
 });
 

--- a/commands.js
+++ b/commands.js
@@ -376,7 +376,7 @@ CmdUtils.CreateCommand({
         var GM = CmdUtils.popupWindow.google.maps;
         
         // http://jsfiddle.net/user2314737/u9no8te4/
-        from = args.input || args.from;
+        var from = args.input || args.from;
         if (!from) {
             previewBlock.innerHTML = "show objects or routes on google maps.<p>syntax: <pre>\tmaps [place] [-l]\n\tmaps -from [start] -to [finish] [-l]\n\n</pre><pre>-l</pre> narrow search to your location"; 
             return;
@@ -387,7 +387,7 @@ CmdUtils.CreateCommand({
     	    var cc = geoIP.country_code || "";
         	cc = cc.toLowerCase();
         }
-        dest = args.finish;
+        var dest = args.to;
         var A = await CmdUtils.get("https://nominatim.openstreetmap.org/search.php?q="+encodeURIComponent(from)+"&polygon_geojson=1&viewbox=&format=json&countrycodes="+cc);
         if (!A[0]) return;
         CmdUtils.deblog("A",A[0]);

--- a/commands.js
+++ b/commands.js
@@ -64,6 +64,28 @@ CmdUtils.CreateCommand({
 });
 
 CmdUtils.CreateCommand({
+    name: "test",
+    takes: {},
+    description: "Close the current tab",
+    author: {},
+    icon: "",
+    homepage: "",
+    license: "",
+    preview: "Close the current tab",
+    execute: function (directObj) {
+        message = ""
+        for (var key in directObj)
+            message += key + " == " + String(directObj[key]) + "\n"
+        console.log(message)
+    },
+    options: {
+        from: { type: "string" },
+        to: { type: "string" },
+        time: { type: "string", def: "now" },
+    },
+});
+
+CmdUtils.CreateCommand({
     name: "yippy",
     description: "Perform a clustered search through yippy.com",
     author: {},

--- a/commands.js
+++ b/commands.js
@@ -188,6 +188,29 @@ CmdUtils.CreateCommand({
 });
 
 CmdUtils.CreateCommand({
+    name: "wordreference",
+    description: "Translates from one to another language.",
+    options: {
+        from: { type: "string" },
+        to: { type: "string" },
+    },
+    preview: async function define_preview(pblock, obj) {
+        pblock.innerHTML = "Gives the meaning of a word.";
+        var text = obj.input;
+        if (!text) return;
+        var from = obj.from || "en";
+        var to = obj.to || "en";
+        var doc = await CmdUtils.get("http://wordreference.com/" + escape(from + to) + "/" + escape(obj.input));
+        doc = jQuery("#articleWRD", doc)
+                .html();
+        pblock.innerHTML = doc;
+    },
+    execute: function (obj) {
+        CmdUtils.addTab("http://wordreference.com/" + escape(obj.from + obj.to) + "/" + escape(obj.input));
+    },
+});
+
+CmdUtils.CreateCommand({
     name: "dramatic-chipmunk",
     takes: {},
     description: "Prepare for a dramatic moment of your life",

--- a/commands.js
+++ b/commands.js
@@ -748,10 +748,10 @@ CmdUtils.CreateCommand({
         email: "admin@pendor.com.ar"
     },
     description: "Search old versions of a site using the Wayback Machine (archive.org)",
-    help: "wayback <i>sitio a buscar</i>",
+    help: "wayback <i>of the website to search</i>",
     icon: "http://web.archive.org/static/images/archive.ico",
-    preview: function (pblock, theShout) {
-        pblock.innerHTML = "Buscar versiones antiguas del sitio <b>" + theShout.text + "</b>";
+    preview: function (pblock, obj) {
+        pblock.innerHTML = "Search old versions of the site <b>" + obj.input + "</b>";
     },
     execute: function (directObj) {
         CmdUtils.closePopup();

--- a/popup.css
+++ b/popup.css
@@ -8,6 +8,10 @@ body {
     font-weight: normal;
 }
 
+pre {
+    display: inline;
+}
+
 #ubiq_window {
     position: fixed;
     left: 0px;
@@ -109,6 +113,7 @@ body {
 }
 
 #ubiq-result-panel {
+    background: #3b3b3b;
     vertical-align: top;
     width: 100%;
     height: 505px;
@@ -126,10 +131,8 @@ body {
 #ubiq-result-panel ul {
 	padding:0; 
 	margin:0;
-    width: 240px; 
+    width: 100%; 
     height: 100%;
-    background: linear-gradient(90deg, #3b3b3b 90%, transparent 10%, rgba(0,0,0,0) 0), #2d2d2d;
-    background-size: 257px auto;
 }
 
 #ubiq-result-panel li {
@@ -141,7 +144,7 @@ body {
 	padding-left: 6px;
 	font-size: 12pt;
 	height: 22pt;
-    width: 225px;
+    width: 100% - 6px;
 	background-color: #a9a9a9;
 	background-repeat: repeat;
     cursor: default;
@@ -154,10 +157,10 @@ body {
 	background-color: #d3d3d3; 
     /* background: linear-gradient(#efefef, #b0b0b0); */
     position:relative;
-    width: 225px;
+    width: 100%;
 }
 #ubiq-result-panel .more-commands {
-    width: 225px;
+    width: 100%;
     line-height: 10px;
     text-align: center;
 }

--- a/popup.js
+++ b/popup.js
@@ -124,7 +124,7 @@ function ubiq_basic_parse() {
 
     // Find command element
     var cmd_struct = CmdUtils.getcmd(command);
-    if (!cmd_struct) return;
+    if (!cmd_struct) return null;
 
     var parsed_object = {
         text: text,
@@ -133,14 +133,10 @@ function ubiq_basic_parse() {
     };
 
     if ("options" in cmd_struct) {
-        // Init the parsed object, if possible with default values for all
-        // options.
-        for (var key in cmd_struct["options"]) {
-            if ("def" in cmd_struct["options"][key])
-                parsed_object[key] = [cmd_struct["options"][key]["def"]];
-            else
-                parsed_object[key] = null;
-        }
+        // Init the parsed object
+        for (var key in cmd_struct["options"])
+            parsed_object[key] = null;
+
         parsed_object["args"] = [];
         parsed_object["input"] = "";
 
@@ -149,7 +145,7 @@ function ubiq_basic_parse() {
         var value_open = false
 
         var update_parsed = function(key, value) {
-            if (!value || value === "") return;
+            if (!value || value === "") return null;
             if (key !== null) {
                 if (!parsed_object[key]) parsed_object[key] = [value];
                 else parsed_object[key].push(value);
@@ -212,8 +208,11 @@ function ubiq_basic_parse() {
         }
         // Add options that were defaulted and not specified
         for (key in cmd_struct["options"]) {
-            if ("def" in cmd_struct["options"][key] && parsed_object["args"].indexOf(key) === -1)
+            if ("def" in cmd_struct["options"][key] && parsed_object["args"].indexOf(key) === -1) {
                 parsed_object["args"].push(key);
+                parsed_object[key] = [cmd_struct["options"][key]["def"]];
+            }
+        }
     }
 
     return parsed_object;

--- a/popup.js
+++ b/popup.js
@@ -99,7 +99,7 @@ function ubiq_basic_parse() {
     var command = words.shift();
 
     var input = words.join(' ').trim();
-    if (text === "") input = CmdUtils.selectedText;
+    if (text === "") input = CmdUtils.selectedText.trim();
 
     // Find command element
     var cmd_struct = CmdUtils.getcmd(command);
@@ -130,9 +130,9 @@ function ubiq_basic_parse() {
             if (key !== null) {
                 switch (cmd_struct["options"][key]["type"]) {
                     case "boolean": parsed_object[key] = value; break;
-                    case "string": parsed_object[key] = value; break;
+                    case "string": parsed_object[key] = value.trim(); break;
                     case "list": {
-                        if (!parsed_object[key]) parsed_object[key] = [value];
+                        if (!parsed_object[key]) parsed_object[key] = [value.trim()];
                         else parsed_object[key].push(value);
                         break;
                     }
@@ -142,7 +142,7 @@ function ubiq_basic_parse() {
                 if (parsed_object["args"].indexOf(key) === -1)
                     parsed_object["args"].push(key);
             } else {
-                parsed_object["input"] = parsed_object["input"].concat(" ").concat(value);
+                parsed_object["input"] = parsed_object["input"].concat(" ").concat(value).trim();
             }
         };
 

--- a/popup.js
+++ b/popup.js
@@ -553,7 +553,7 @@ function ubiq_keydown_handler(evt) {
 }
 
 function ubiq_keyup_handler(evt) {
-    ubiq_show_matching_commands();
+    ubiq_show_command_options();
 }
 
 function ubiq_save_input() {

--- a/popup.js
+++ b/popup.js
@@ -527,6 +527,16 @@ function ubiq_keydown_handler(evt) {
         return;
     }
 
+    // On TAB, try to autocomplete command
+    if (kc == 9) {
+        command = ubiq_complete_command();
+        if (command !== null) {
+            ubiq_input().value = command;
+        }
+        ubiq_focus();
+        return;
+    }
+
     // On F5 restart extension
     if (kc == 116) {
         chrome.runtime.reload();

--- a/popup.js
+++ b/popup.js
@@ -113,7 +113,7 @@ function ubiq_basic_parse() {
     var parsed_object = {
         text: text,
         command: command,
-        input: input,
+        input: selection ? input : "",
         _selection: selection,
         _cmd: cmd_struct
     };
@@ -130,13 +130,23 @@ function ubiq_basic_parse() {
         var value_open = false
 
         var update_parsed = function(key, value) {
-            if (value === null || value === "") return null;
+            if (value === null) return;
             if (key !== null) {
                 switch (cmd_struct["options"][key]["type"]) {
-                    case "boolean": parsed_object[key] = value; break;
-                    case "string": parsed_object[key] = value.trim(); break;
+                    case "boolean": {
+                        parsed_object[key] = Boolean(value); 
+                        break;
+                    }
+                    case "string": {
+                        value = String(value).trim();
+                        if (value === "") return;
+                        parsed_object[key] = value;
+                        break;
+                    }
                     case "list": {
-                        if (!parsed_object[key]) parsed_object[key] = [value.trim()];
+                        value = String(value).trim();
+                        if (value === "") return;
+                        if (!parsed_object[key]) parsed_object[key] = [value];
                         else parsed_object[key].push(value);
                         break;
                     }

--- a/popup.js
+++ b/popup.js
@@ -232,11 +232,11 @@ function ubiq_execute() {
     // Create a fake Ubiquity-like object, to pass to
     // command's "execute" function
     var cmd_func = cmd_struct.execute;
-    var directObj = { 
-        text: text,
-        _selection: text==CmdUtils.selectedText,
-        _cmd: cmd_struct
-    };
+    var directObj = ubiq_basic_parse();
+    if (!directObj) return;
+
+    directObj._selection = (text==CmdUtils.selectedText);
+    directObj._cmd = cmd_struct;
 
     // Run command's "execute" function
     try {

--- a/popup.js
+++ b/popup.js
@@ -179,7 +179,7 @@ function ubiq_input() {
 }
 
 function ubiq_command() {
-    var cmd = document.getElementById('ubiq_input');
+    var cmd = ubiq_input();
 
     if (!cmd) return '';
     return cmd.value;

--- a/popup.js
+++ b/popup.js
@@ -99,7 +99,12 @@ function ubiq_basic_parse() {
     var command = words.shift();
 
     var input = words.join(' ').trim();
-    if (text === "") input = CmdUtils.selectedText.trim();
+
+    var selection = false;
+    if (input === "") {
+        input = CmdUtils.selectedText.trim();
+        selection = true;
+    }
 
     // Find command element
     var cmd_struct = CmdUtils.getcmd(command);
@@ -109,7 +114,7 @@ function ubiq_basic_parse() {
         text: text,
         command: command,
         input: input,
-        _selection: (input==CmdUtils.selectedText),
+        _selection: selection,
         _cmd: cmd_struct
     };
 
@@ -119,7 +124,6 @@ function ubiq_basic_parse() {
             parsed_object[key] = null;
 
         parsed_object["args"] = [];
-        parsed_object["input"] = "";
 
         var current_key = null;
         var current_value = [];
@@ -213,9 +217,6 @@ function ubiq_execute() {
     var words = ubiq_command().split(' ');
     var command = words.shift();
 
-    var text = words.join(' ').trim();
-    if (text=="") text = CmdUtils.selectedText;
-
     // Find command element
     cmd_struct = CmdUtils.getcmd(command);
     if (!cmd_struct) return;
@@ -228,7 +229,7 @@ function ubiq_execute() {
 
     // Run command's "execute" function
     try {
-        CmdUtils.deblog("executing [", cmd,"] [", text,"]");
+        CmdUtils.deblog("executing [", directObj.cmd ,"] [", directObj.input ,"]");
         cmd_func(directObj);
     } catch (e) {
         CmdUtils.notify(e.toString(), "execute function error")

--- a/popup.js
+++ b/popup.js
@@ -115,29 +115,15 @@ function ubiq_show_preview(cmd, args) {
 }
 
 function ubiq_execute() {
-    var cmd = ubiq_command();
-    if (!cmd) return false;
-    ubiq_dispatch_command(cmd);
-    return false;
-}
-
-function ubiq_dispatch_command(line, args) {
     var words = ubiq_command().split(' ');
     var command = words.shift();
 
     var text = words.join(' ').trim();
     if (text=="") text = CmdUtils.selectedText;
 
-    // Expand match (typing 'go' will expand to 'google')
-    cmd = ubiq_match_first_command(cmd);
-    ubiq_replace_first_word(cmd);
-
     // Find command element
-    var cmd_struct = CmdUtils.getcmd( cmd );
-
-    if (!cmd_struct) {
-        return;
-    }
+    cmd_struct = CmdUtils.getcmd(command);
+    if (!cmd_struct) return;
 
     // Create a fake Ubiquity-like object, to pass to
     // command's "execute" function
@@ -176,7 +162,7 @@ function ubiq_help() {
 }
 
 function ubiq_focus() {
-    el = document.getElementById('ubiq_input');
+    el = ubiq_command();
     if (el.createTextRange) {
         var oRange = el.createTextRange();
         oRange.moveStart("character", 0);
@@ -190,32 +176,9 @@ function ubiq_focus() {
 
 function ubiq_command() {
     var cmd = document.getElementById('ubiq_input');
-    if (!cmd) {
-        ubiq_selected_command = -1;
-        return '';
-    }
+
+    if (!cmd) return '';
     return cmd.value;
-}
-
-function ubiq_match_first_command(text) {
-    if (!text) text = ubiq_command();
-    var first_match = '';
-
-    // Command selected through cursor UP/DOWN
-    if (ubiq_first_match) {
-        return ubiq_first_match;
-    }
-
-    if (text.length > 0) {
-        for (var c in CmdUtils.CommandList) {
-            c = CmdUtils.CommandList[c].name;
-            if (c.match(RegExp('^'+text,"i"))) {
-                first_match = c;
-                break;
-            }
-        }
-    }
-    return first_match;
 }
 
 function _ubiq_image_error(elm) { 
@@ -232,17 +195,6 @@ function ubiq_command_icon(c) {
 
 function ubiq_command_name(c) {
     return CmdUtils.CommandList[c].name;
-}
-
-function ubiq_replace_first_word(w) {
-    if (!w) return;
-    var text = ubiq_command();
-    var words = text.split(' ');
-    words[0] = w;
-    var cmd_line = document.getElementById('ubiq_input');
-    if (!cmd_line) return;
-    cmd_line.value = words.join(' ');
-    return;
 }
 
 function ubiq_fuzzy_search(needle, haystack) {
@@ -462,12 +414,12 @@ function ubiq_keyup_handler(evt) {
 }
 
 function ubiq_save_input() {
-	cmd = document.getElementById('ubiq_input');
+	cmd = ubiq_command();
     if (typeof chrome !== 'undefined' && chrome.storage) chrome.storage.local.set({ 'lastCmd': cmd.value });
 }
 
 function ubiq_load_input(callback) {
-	cmd = document.getElementById('ubiq_input');
+	cmd = ubiq_command();
     if (typeof chrome !== 'undefined' && chrome.storage) chrome.storage.local.get('lastCmd', function(result) {
         lastCmd = result.lastCmd || "";
         cmd.value = lastCmd;

--- a/popup.js
+++ b/popup.js
@@ -365,8 +365,6 @@ function ubiq_show_matching_commands(text) {
     return;
 }
 
-var lcmd = "";
-
 function ubiq_keydown_handler(evt) {
 	// measure the input 
 	CmdUtils.inputUpdateTime = performance.now();
@@ -394,23 +392,6 @@ function ubiq_keydown_handler(evt) {
         if (!el) return;
         CmdUtils.setClipboard( el.innerText );
     }
-
-    // Cursor up
-    if (kc == 38) {
-        ubiq_selected_command--;
-        lcmd = "";
-        evt.preventDefault();
-    }
-    // Cursor Down
-    else if (kc == 40) {
-        ubiq_selected_command++;
-        lcmd = "";
-        evt.preventDefault();
-    }
-
-    if (lcmd==ubiq_command()) return;
-    ubiq_show_matching_commands();
-    lcmd=ubiq_command();
 }
 
 function ubiq_keyup_handler(evt) {

--- a/popup.js
+++ b/popup.js
@@ -267,15 +267,7 @@ function ubiq_help() {
 
 function ubiq_focus() {
     el = ubiq_input();
-    if (el.createTextRange) {
-        var oRange = el.createTextRange();
-        oRange.moveStart("character", 0);
-        oRange.moveEnd("character", el.value.length);
-        oRange.select();
-    } else if (el.setSelectionRange) {
-        el.setSelectionRange(0, el.value.length);
-    }
-    el.focus();
+    setTimeout("el.focus()", 50);
 }
 
 function ubiq_input() {

--- a/popup.js
+++ b/popup.js
@@ -162,7 +162,7 @@ function ubiq_help() {
 }
 
 function ubiq_focus() {
-    el = ubiq_command();
+    el = ubiq_input();
     if (el.createTextRange) {
         var oRange = el.createTextRange();
         oRange.moveStart("character", 0);
@@ -172,6 +172,10 @@ function ubiq_focus() {
         el.setSelectionRange(0, el.value.length);
     }
     el.focus();
+}
+
+function ubiq_input() {
+    return document.getElementById('ubiq_input');
 }
 
 function ubiq_command() {
@@ -414,12 +418,12 @@ function ubiq_keyup_handler(evt) {
 }
 
 function ubiq_save_input() {
-	cmd = ubiq_command();
+	cmd = ubiq_input();
     if (typeof chrome !== 'undefined' && chrome.storage) chrome.storage.local.set({ 'lastCmd': cmd.value });
 }
 
 function ubiq_load_input(callback) {
-	cmd = ubiq_command();
+	cmd = ubiq_input();
     if (typeof chrome !== 'undefined' && chrome.storage) chrome.storage.local.get('lastCmd', function(result) {
         lastCmd = result.lastCmd || "";
         cmd.value = lastCmd;

--- a/popup.js
+++ b/popup.js
@@ -1,11 +1,11 @@
 //
 // UbiChr a Ubiquity for Chrome
 // rostok@3e.pl
-// 
+//
 // based on http://github.com/cosimo/ubiquity-chrome/ by Cosimo Streppone, <cosimo@cpan.org>
 //
 // Original Ubiquity Project: http://labs.mozilla.org/ubiquity/
-// jshint esversion: 6 
+// jshint esversion: 6
 
 var ubiq_selected_command = 0;
 var ubiq_first_match;
@@ -34,7 +34,7 @@ function ubiq_preview_set_visible(v) {
 // sets preview panel, prepend allows to add new contnet to the top separated by HR
 function ubiq_set_preview(v, prepend) {
     v = v || "";
-    prepend = prepend === true; 
+    prepend = prepend === true;
     var el = ubiq_preview_el();
     if (!el) return;
     el.innerHTML = v + (prepend ? "<hr/>" + el.innerHTML : "");
@@ -48,7 +48,7 @@ function ubiq_result_el() {
 // sets result panel, prepend allows to add new contnet to the top separated by HR
 function ubiq_set_result(v, prepend) {
     v = v || "";
-    prepend = prepend === true; 
+    prepend = prepend === true;
     var el = ubiq_result_el();
     if (!el) return;
     el.innerHTML = v + (prepend ? "<hr/>" + el.innerHTML : "");
@@ -73,16 +73,16 @@ function ubiq_show_preview(cmd, args) {
     case 'undefined':
         	ubiq_set_preview( cmd_struct.description );
         	break;
-    case 'string': 
+    case 'string':
             ubiq_set_preview( preview_func );
         	break;
     default:
         var words = ubiq_command().split(' ');
         var command = words.shift();
-    
+
         var text = words.join(' ').trim();
         if (text=="") text = CmdUtils.selectedText;
-    
+
         var directObj = {
             text: text,
             _selection: text==CmdUtils.selectedText,
@@ -91,7 +91,7 @@ function ubiq_show_preview(cmd, args) {
 
         var pfunc = ()=>{
             // zoom overflow dirty fix
-            CmdUtils.popupWindow.jQuery("#ubiq-command-preview").css("overflow-y", "auto"); 
+            CmdUtils.popupWindow.jQuery("#ubiq-command-preview").css("overflow-y", "auto");
             try {
                 (preview_func.bind(cmd_struct))(ubiq_preview_el(), directObj);
             } catch (e) {
@@ -290,7 +290,7 @@ function ubiq_command() {
     return cmd.value;
 }
 
-function _ubiq_image_error(elm) { 
+function _ubiq_image_error(elm) {
     elm.src = 'res/spacer.png';
 };
 function ubiq_command_icon(c) {
@@ -471,7 +471,7 @@ function ubiq_show_matching_commands(text) {
 }
 
 function ubiq_keydown_handler(evt) {
-	// measure the input 
+	// measure the input
 	CmdUtils.inputUpdateTime = performance.now();
 	ubiq_save_input();
 
@@ -525,10 +525,10 @@ $(window).on('load', function() {
         CmdUtils.setResult = ubiq_set_result;
         CmdUtils.popupWindow = window;
         CmdUtils.updateActiveTab();
-        
+
         ubiq_load_input(()=>{ubiq_show_matching_commands();});
-        
-        // Add event handler to window 
+
+        // Add event handler to window
         document.addEventListener('keydown', function(e) { ubiq_keydown_handler(e); }, false);
         document.addEventListener('keyup', function(e) { ubiq_keyup_handler(e); }, false);
 

--- a/popup.js
+++ b/popup.js
@@ -347,6 +347,58 @@ function ubiq_html_encode(text) {
     return ubiq_html_encoder.html(text).text();
 }
 
+function ubiq_complete_command(text) {
+    if (!text) text = ubiq_command();
+
+    var words = text.split(' ');
+    if (words.length > 1) return null;
+
+    var command = words[0];
+    if (command.length == 0) return null;
+
+    matches = [];
+    for (var c in CmdUtils.CommandList) {
+        var cmdnames = CmdUtils.CommandList[c].names;
+        for (var cmd of cmdnames)
+            if (cmd.startsWith(command))
+                matches.push(cmd);
+    }
+
+    if (matches.length == 0) return null;
+    if (matches.length == 1) return matches[0];
+
+    ubiq_set_preview(matches.join(', '));
+    return null;
+}
+
+function ubiq_show_command_options() {
+    var parsed = ubiq_basic_parse();
+    if (!parsed) return;
+
+    var cmd_struct = CmdUtils.getcmd(parsed.command);
+    if (!("options" in cmd_struct)) return;
+
+    var options_div = document.createElement('div');
+    var options_list = document.createElement('ul');
+
+    for (var key in cmd_struct["options"]) {
+        li = document.createElement('LI');
+        var val = cmd_struct["options"][key]["type"];
+        if (parsed[key])
+            val = String(parsed[key]);
+        li.innerHTML = ubiq_html_encode(key + " => " + val);
+
+        options_list.appendChild(li);
+    }
+
+    li = document.createElement('LI');
+    li.innerHTML = ubiq_html_encode("input => " + parsed["input"]);
+    options_list.appendChild(li);
+
+    options_div.appendChild(options_list);
+    ubiq_result_el().innerHTML = options_div.innerHTML;
+}
+
 // will also call preview
 function ubiq_show_matching_commands(text) {
     const max_matches = 15;


### PR DESCRIPTION
So I'm starting to work on the new parsing and I'd love to know what you thing (I'll be doing more just now but I'd love to get your feedback ASAP).

So personally I want to remove the fact that one can choose commands with the arrow keys. Instead, the space reserved for commands should be reserved to show a command's options and description, like an automatic manual.

In order to know which commands are available, a simple "help" command could be done, the output of which are the available command names.

At the same time, I'd also like to remove fuzzy matching from commands, as typing the name of a command correctly should be easy. Also keep in mind that commands already have aliases, so if one wants a shorter way to use a command that can be arranged.

Next step would be modifying the commands to offer options, and parsing them. I could put the parsing in a separate file? Let me know what you think.